### PR TITLE
Specify include file in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=
 category=Sensors
 url=https://github.com/olkal/HX711_ADC
 architectures=*
-includes=
+includes=HX711_ADC.h


### PR DESCRIPTION
Previously the `includes` property of library.properties was left blank which caused **Sketch > Include Library > HX711_ADC** to incorrectly add the following line to the sketch:
```c++
#include <>
```
This change causes it to produce the expected behavior of adding the line:
```c++
#include <HX711_ADC.h>
```
to the sketch.

Note that since this library currently only contains a single header file, not defining an `includes` property in library.properties would achieve the same behavior.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format