### PR TITLE
Bugfix in startMultiple 

### DIFF
--- a/src/HX711_ADC.cpp
+++ b/src/HX711_ADC.cpp
@@ -59,12 +59,17 @@ int HX711_ADC::start(unsigned int t)
 int HX711_ADC::startMultiple(unsigned int t)
 {
 	if(startStatus == 0) {
-		unsigned long ts = millis();
 		if(isFirst) {
-			t += 400; //min time for HX711 to be stable
+			startMultipleTimeStamp = millis();
+
+			if (t < 400) {
+			startMultipleWaitTime = t + 400; //min time for HX711 to be stable
+			} else {
+				startMultipleWaitTime = t;
+			}
 			isFirst = 0;
 		}	
-		if(millis() < ts + t) {
+		if(millis() < startMultipleTimeStamp + startMultipleWaitTime) {
 			update(); //do conversions during stabilization time
 			return 0;
 		}

--- a/src/HX711_ADC.h
+++ b/src/HX711_ADC.h
@@ -83,6 +83,8 @@ class HX711_ADC
 		const uint8_t divBit = DIVB;
 		bool doTare;
 		bool startStatus;
+		long startMultipleTimeStamp;
+		long startMultipleWaitTime;
 		uint8_t convRslt;
 		bool tareStatus;
 		unsigned int tareTimeOut = (SAMPLES + IGN_HIGH_SAMPLE + IGN_HIGH_SAMPLE) * 150; // tare timeout time in ms, no of samples * 150ms (10SPS + 50% margin)


### PR DESCRIPTION
Fixed a bug in the  startMultiple function which causes the function to never succeed as the timestamp gets reset every call. Also adding the 400ms has no effect (byval) which is fixed in this version.