### PR TITLE
rename ISR function, add digitalPinToInterrupt

### DIFF
--- a/examples/Read_1x_load_cell_interrupt_driven/Read_1x_load_cell_interrupt_driven.ino
+++ b/examples/Read_1x_load_cell_interrupt_driven/Read_1x_load_cell_interrupt_driven.ino
@@ -46,11 +46,12 @@ void setup() {
     LoadCell.setCalFactor(calValue); // set calibration value (float)
     Serial.println("Startup + tare is complete");
   }
-  attachInterrupt(doutPin, ISR, FALLING);
+
+  attachInterrupt(digitalPinToInterrupt(doutPin), whenreadyISR, FALLING);
 }
 
 //interrupt routine:
-void ISR() {
+void whenreadyISR() {
   LoadCell.update();
 }
 


### PR DESCRIPTION
I have a compilation error using ISR as function name, it works begining with lower case.
The error was:
Read_1x_load_cell_interrupt_driven:53:6: error: expected ')' before 'void'
exit status 1
'ISR' was not declared in this scope

I have added the use of digitalPinToInterrupt() (cf: https://www.arduino.cc/reference/en/language/functions/external-interrupts/attachinterrupt/)
attachInterrupt take the number of interrupt, it was the pin number in the example.