### PR TITLE
Fix timers for initial conversions in start()

### DIFF
--- a/src/HX711_ADC.cpp
+++ b/src/HX711_ADC.cpp
@@ -47,8 +47,9 @@ void HX711_ADC::begin(uint8_t gain)
 void HX711_ADC::start(unsigned long t)
 {
 	t += 400;
+	unsigned long startTime = millis();
 	lastDoutLowTime = millis();
-	while(millis() < t) 
+	while(millis() < startTime + t) 
 	{
 		update();
 		yield();
@@ -63,8 +64,9 @@ void HX711_ADC::start(unsigned long t)
 void HX711_ADC::start(unsigned long t, bool dotare)
 {
 	t += 400;
+	unsigned long startTime = millis();
 	lastDoutLowTime = millis();
-	while(millis() < t) 
+	while(millis() < startTime + t) 
 	{
 		update();
 		yield();

--- a/src/config.h
+++ b/src/config.h
@@ -40,6 +40,6 @@ Note that you can also overide (reducing) the number of samples in use at any ti
 
 //if you have some other time consuming (>60μs) interrupt routines that trigger while the sck pin is high, this could unintentionally set the HX711 into "power down" mode
 //if required you can change the value to '1' to disable interrupts when writing to the sck pin.
-#define SCK_DISABLE_INTERRUPTS		0		//default value: 0
+#define SCK_DISABLE_INTERRUPTS		1		//default value: 0
 
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -36,7 +36,7 @@ Note that you can also overide (reducing) the number of samples in use at any ti
 //microsecond delay after writing sck pin high or low. This delay could be required for faster mcu's.
 //So far the only mcu reported to need this delay is the ESP32 (issue #35), both the Arduino Due and ESP8266 seems to run fine without it.
 //Change the value to '1' to enable the delay.
-#define SCK_DELAY					0		//default value: 0
+#define SCK_DELAY					1		//default value: 0
 
 //if you have some other time consuming (>60μs) interrupt routines that trigger while the sck pin is high, this could unintentionally set the HX711 into "power down" mode
 //if required you can change the value to '1' to disable interrupts when writing to the sck pin.


### PR DESCRIPTION
Hi
Thanks for your great library!
I spotted a small bug in `start()` (both versions) where you just checked if the current `millis()` value was greater than the delay time, instead of using a baseline of the time at which the function started. That meant these functions would never delay for the correct amount of time, and might not delay at all if `start()` was not called near the beginning of `setup()`. This could lead to wildly anomalous readings! 
Cheers
Ben