### PR TITLE
Add another begin() method...

### DIFF
--- a/src/HX711_ADC.cpp
+++ b/src/HX711_ADC.cpp
@@ -41,6 +41,16 @@ void HX711_ADC::begin(uint8_t gain)
 	powerUp();
 }
 
+//set pins and pinMode, HX711 selected gain and power up the HX711
+void HX711_ADC::begin(uint8_t dout, uint8_t sck, uint8_t gain) {
+    doutPin = dout;  // Assign new pin numbers
+    sckPin = sck;
+    pinMode(sckPin, OUTPUT);
+    pinMode(doutPin, INPUT);
+    setGain(gain);
+    powerUp();
+}
+
 /*  start(t): 
 *	will do conversions continuously for 't' +400 milliseconds (400ms is min. settling time at 10SPS). 
 *   Running this for 1-5s in setup() - before tare() seems to improve the tare accuracy */

--- a/src/HX711_ADC.h
+++ b/src/HX711_ADC.h
@@ -54,6 +54,7 @@ class HX711_ADC
 		void setGain(uint8_t gain = 128); 			//value must be 32, 64 or 128*
 		void begin();								//set pinMode, HX711 gain and power up the HX711
 		void begin(uint8_t gain);					//set pinMode, HX711 selected gain and power up the HX711
+		void begin(uint8_t dout, uint8_t sck, uint8_t gain = 128); //set pins and pinMode, HX711 selected gain and power up the HX711
 		void start(unsigned long t); 					//start HX711 and do tare 
 		void start(unsigned long t, bool dotare);		//start HX711, do tare if selected
 		int startMultiple(unsigned long t); 			//start and do tare, multiple HX711 simultaniously


### PR DESCRIPTION
I have projects that use the same load cells. Older projects used one set of dout and sck pins. Now I use another set of pins. I use the same sketch to program them all. Using this new begin method allows me to change pins during setup based on the stored values in NVS.

LoadCell_1.begin(HX711_dout_1, HX711_sck_1, 128)

I've tested and works great for me. 